### PR TITLE
Add seed-based world generation controls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -56,6 +56,90 @@
   font-weight: 700;
 }
 
+.seed-form {
+  margin-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  text-align: left;
+}
+
+.seed-form label {
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.seed-actions {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.seed-input {
+  flex: 1 1 160px;
+  min-width: 0;
+  padding: 0.55rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(9, 16, 24, 0.65);
+  color: #f3efe4;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.seed-input::placeholder {
+  color: rgba(243, 239, 228, 0.55);
+}
+
+.seed-input:focus {
+  outline: none;
+  border-color: rgba(255, 225, 176, 0.8);
+  box-shadow: 0 0 0 1px rgba(255, 225, 176, 0.35);
+}
+
+.seed-button {
+  padding: 0.55rem 0.85rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: rgba(27, 40, 55, 0.7);
+  color: #f6f2e8;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease, border-color 0.2s ease;
+}
+
+.seed-button:hover {
+  background: rgba(45, 70, 96, 0.8);
+  border-color: rgba(255, 225, 176, 0.55);
+}
+
+.seed-button:active {
+  transform: translateY(1px);
+}
+
+.seed-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  opacity: 0.75;
+  flex-wrap: wrap;
+}
+
+.seed-hint {
+  color: rgba(245, 237, 222, 0.8);
+}
+
+.seed-status {
+  color: #ffe5b0;
+  font-weight: 600;
+}
+
 @media (max-width: 720px) {
   .overlay {
     top: 1rem;
@@ -65,5 +149,19 @@
   .stats {
     flex-direction: column;
     gap: 0.4rem;
+  }
+
+  .seed-actions {
+    flex-direction: column;
+  }
+
+  .seed-button {
+    width: 100%;
+    text-align: center;
+  }
+
+  .seed-footer {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- add seeded world generation utilities so islands and waves are reproducible from a shared seed
- expose UI controls to load, randomize, and copy seeds while resetting boat and wave state
- style the overlay to accommodate the new seed management controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df3a133868832490e5baaf49875d44