### PR TITLE
Restyle sailing HUD with top and bottom panels

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,7 +3,7 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  color: #f2ede3;
+  color: #f6f0e6;
 }
 
 .world-canvas {
@@ -13,155 +13,236 @@
   background: transparent;
 }
 
-.overlay {
+.ui-layer {
   position: absolute;
-  top: 1.5rem;
-  left: 50%;
-  transform: translateX(-50%);
-  padding: 1.25rem 2rem;
-  border-radius: 18px;
-  background: rgba(10, 18, 26, 0.45);
-  box-shadow: 0 25px 45px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(12px);
-  text-align: center;
-  max-width: min(90vw, 520px);
-}
-
-.title {
-  font-size: clamp(1.5rem, 2vw + 1rem, 2.2rem);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  margin-bottom: 0.75rem;
-  font-weight: 600;
-}
-
-.stats {
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-  font-size: 0.95rem;
-  letter-spacing: 0.06em;
-  margin-bottom: 0.75rem;
-  opacity: 0.9;
-}
-
-.instructions {
-  font-size: 0.9rem;
-  line-height: 1.5;
-  opacity: 0.82;
-}
-
-.instructions strong {
-  color: #ffe5b0;
-  font-weight: 700;
-}
-
-.seed-form {
-  margin-top: 1.25rem;
+  inset: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
-  text-align: left;
+  justify-content: space-between;
+  padding: 1.5rem 2.5rem 2rem;
+  pointer-events: none;
 }
 
-.seed-form label {
-  font-size: 0.7rem;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  opacity: 0.7;
+.glass-panel {
+  pointer-events: auto;
+  background: linear-gradient(135deg, rgba(8, 36, 48, 0.75), rgba(14, 60, 76, 0.68));
+  border: 1px solid rgba(148, 224, 222, 0.35);
+  border-radius: 24px;
+  box-shadow: 0 22px 55px rgba(5, 18, 27, 0.45);
+  backdrop-filter: blur(14px);
+  color: #f6f1e8;
 }
 
-.seed-actions {
+.top-menu {
+  align-self: center;
+  width: min(100%, 1100px);
   display: flex;
-  gap: 0.45rem;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.85rem 1.75rem;
   flex-wrap: wrap;
 }
 
+.menu-brand {
+  font-size: clamp(1.5rem, 2vw + 1rem, 2.25rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #ffe7bd;
+  text-shadow: 0 6px 14px rgba(0, 0, 0, 0.45);
+}
+
+.menu-instructions {
+  font-size: 0.9rem;
+  line-height: 1.3;
+  color: rgba(240, 245, 248, 0.92);
+  max-width: 320px;
+}
+
+.menu-instructions strong {
+  color: #ffe7bd;
+  font-weight: 600;
+}
+
+.seed-form {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+}
+
+.seed-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(240, 245, 248, 0.68);
+}
+
 .seed-input {
-  flex: 1 1 160px;
-  min-width: 0;
-  padding: 0.55rem 0.75rem;
-  border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(9, 16, 24, 0.65);
-  color: #f3efe4;
+  flex: 1 1 220px;
+  min-width: 180px;
+  padding: 0.55rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: rgba(10, 40, 54, 0.72);
+  color: #f8f4eb;
   font-size: 0.95rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .seed-input::placeholder {
-  color: rgba(243, 239, 228, 0.55);
+  color: rgba(235, 244, 245, 0.55);
 }
 
 .seed-input:focus {
   outline: none;
-  border-color: rgba(255, 225, 176, 0.8);
-  box-shadow: 0 0 0 1px rgba(255, 225, 176, 0.35);
+  background: rgba(18, 54, 70, 0.85);
+  border-color: rgba(255, 222, 178, 0.6);
+  box-shadow: 0 0 0 1px rgba(255, 222, 178, 0.3);
+}
+
+.seed-buttons {
+  display: flex;
+  gap: 0.45rem;
 }
 
 .seed-button {
-  padding: 0.55rem 0.85rem;
-  border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.24);
-  background: rgba(27, 40, 55, 0.7);
-  color: #f6f2e8;
-  font-size: 0.85rem;
-  letter-spacing: 0.05em;
+  padding: 0.55rem 0.95rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  background: linear-gradient(135deg, rgba(255, 210, 148, 0.78), rgba(255, 178, 107, 0.78));
+  color: #1f2e36;
+  font-weight: 600;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.15s ease, border-color 0.2s ease;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .seed-button:hover {
-  background: rgba(45, 70, 96, 0.8);
-  border-color: rgba(255, 225, 176, 0.55);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+  border-color: rgba(255, 234, 205, 0.75);
 }
 
 .seed-button:active {
   transform: translateY(1px);
 }
 
-.seed-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.75rem;
-  font-size: 0.8rem;
-  opacity: 0.75;
-  flex-wrap: wrap;
-}
-
 .seed-hint {
-  color: rgba(245, 237, 222, 0.8);
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-size: 0.82rem;
+  color: rgba(240, 245, 248, 0.8);
 }
 
 .seed-status {
-  color: #ffe5b0;
+  color: #ffe3a5;
   font-weight: 600;
 }
 
-@media (max-width: 720px) {
-  .overlay {
-    top: 1rem;
-    padding: 1rem 1.4rem;
+.bottom-menu {
+  align-self: center;
+  width: min(100%, 520px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 0.85rem 1.6rem;
+}
+
+.ship-title {
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(255, 231, 189, 0.95);
+}
+
+.ship-stats {
+  display: flex;
+  gap: 1.75rem;
+}
+
+.ship-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.ship-stat-label {
+  font-size: 0.65rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(240, 245, 248, 0.65);
+}
+
+.ship-stat-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #fef7dc;
+  text-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+}
+
+@media (max-width: 900px) {
+  .ui-layer {
+    padding: 1.2rem 1.2rem 1.6rem;
   }
 
-  .stats {
-    flex-direction: column;
-    gap: 0.4rem;
+  .top-menu {
+    gap: 1rem;
+    padding: 0.75rem 1.25rem;
   }
 
-  .seed-actions {
-    flex-direction: column;
+  .menu-instructions {
+    max-width: 100%;
+  }
+
+  .seed-form {
+    width: 100%;
+  }
+
+  .seed-input {
+    flex: 1 1 160px;
+  }
+
+  .bottom-menu {
+    width: min(100%, 420px);
+    padding: 0.75rem 1.2rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .menu-brand {
+    flex: 1 1 100%;
+  }
+
+  .menu-instructions {
+    font-size: 0.85rem;
+  }
+
+  .seed-buttons {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
   }
 
   .seed-button {
-    width: 100%;
+    flex: 1 1 90px;
     text-align: center;
   }
 
-  .seed-footer {
+  .seed-hint {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .ship-stats {
+    gap: 1rem;
+  }
+
+  .ship-stat-value {
+    font-size: 1rem;
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -459,21 +459,16 @@ function App() {
   return (
     <div className="app">
       <canvas ref={canvasRef} className="world-canvas" />
-      <div className="overlay">
-        <div className="title">SailTrade</div>
-        <div className="stats">
-          <span>Speed: {Math.round(boatState.speed)} kn</span>
-          <span>
-            Heading: {Math.round((((boatState.heading % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2)) * (180 / Math.PI))}
-            °
-          </span>
-        </div>
-        <div className="instructions">
-          Press <strong>↑</strong>/<strong>W</strong> to catch more wind, <strong>↓</strong>/<strong>S</strong> to trim your sails, and use <strong>←</strong>/<strong>→</strong> or <strong>A</strong>/<strong>D</strong> to turn the bow.
-        </div>
-        <form className="seed-form" onSubmit={handleSeedSubmit}>
-          <label htmlFor="seed-input">World seed</label>
-          <div className="seed-actions">
+      <div className="ui-layer">
+        <div className="top-menu glass-panel">
+          <div className="menu-brand">SailTrade</div>
+          <div className="menu-instructions">
+            Catch the wind with <strong>↑</strong>/<strong>W</strong>, ease the sails with <strong>↓</strong>/<strong>S</strong>, and steer using <strong>←</strong>/<strong>→</strong> or <strong>A</strong>/<strong>D</strong>.
+          </div>
+          <form className="seed-form" onSubmit={handleSeedSubmit}>
+            <label htmlFor="seed-input" className="seed-label">
+              World Seed
+            </label>
             <input
               id="seed-input"
               className="seed-input"
@@ -482,21 +477,38 @@ function App() {
               placeholder="Enter or paste a seed"
               spellCheck="false"
             />
-            <button type="submit" className="seed-button">
-              Load
-            </button>
-            <button type="button" className="seed-button" onClick={handleRandomSeed}>
-              Random
-            </button>
-            <button type="button" className="seed-button" onClick={handleCopySeed}>
-              Copy
-            </button>
-          </div>
-          <div className="seed-footer">
-            <span className="seed-hint">Share this seed to sail the same waters.</span>
+            <div className="seed-buttons">
+              <button type="submit" className="seed-button">
+                Load
+              </button>
+              <button type="button" className="seed-button" onClick={handleRandomSeed}>
+                Random
+              </button>
+              <button type="button" className="seed-button" onClick={handleCopySeed}>
+                Copy
+              </button>
+            </div>
+          </form>
+          <div className="seed-hint">
+            <span>Share this seed to sail the same waters.</span>
             {copyStatus && <span className="seed-status">{copyStatus}</span>}
           </div>
-        </form>
+        </div>
+        <div className="bottom-menu glass-panel">
+          <div className="ship-title">Ship</div>
+          <div className="ship-stats">
+            <div className="ship-stat">
+              <span className="ship-stat-label">Speed</span>
+              <span className="ship-stat-value">{Math.round(boatState.speed)} kn</span>
+            </div>
+            <div className="ship-stat">
+              <span className="ship-stat-label">Heading</span>
+              <span className="ship-stat-value">
+                {Math.round((((boatState.heading % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2)) * (180 / Math.PI))}°
+              </span>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   )
@@ -547,9 +559,9 @@ function drawScene(ctx, viewport, boat, islands, waves) {
 
 function paintSea(ctx, width, height, camera, waves) {
   const gradient = ctx.createLinearGradient(0, 0, width, height)
-  gradient.addColorStop(0, '#102a4d')
-  gradient.addColorStop(0.5, '#114b73')
-  gradient.addColorStop(1, '#0a243b')
+  gradient.addColorStop(0, '#2bb9c6')
+  gradient.addColorStop(0.55, '#1f9fb3')
+  gradient.addColorStop(1, '#0b4969')
   ctx.fillStyle = gradient
   ctx.fillRect(0, 0, width, height)
 

--- a/src/index.css
+++ b/src/index.css
@@ -2,8 +2,8 @@
   font-family: 'Spectral', 'Palatino Linotype', 'Book Antiqua', serif;
   line-height: 1.5;
   font-weight: 400;
-  color: #f2ede3;
-  background-color: #0f1c27;
+  color: #f7f1e6;
+  background-color: #0c2633;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -25,7 +25,7 @@ a:hover {
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top, #24445a 0%, #0f1c27 65%, #071018 100%);
+  background: radial-gradient(circle at top, #3ba9b8 0%, #0c4f67 55%, #092030 100%);
 }
 
 #root {


### PR DESCRIPTION
## Summary
- reshape the primary interface into a slim top menu and add a matching ship status footer
- refresh seed controls and glass styling to align with the illustrated inspiration
- adjust background and ocean gradients for a brighter tropical palette

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e04e0c7d208324badcbd1fdbf95455