### PR TITLE
Make top and bottom UI panels collapsible with ship status indicator

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -37,9 +37,21 @@
   align-self: center;
   width: min(100%, 1100px);
   display: flex;
-  align-items: center;
-  gap: 1.5rem;
+  flex-direction: column;
+  gap: 0;
   padding: 0.85rem 1.75rem;
+}
+
+.top-menu--expanded {
+  gap: 1rem;
+  padding-bottom: 1.35rem;
+}
+
+.top-menu-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
   flex-wrap: wrap;
 }
 
@@ -52,11 +64,49 @@
   text-shadow: 0 6px 14px rgba(0, 0, 0, 0.45);
 }
 
+.menu-actions {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.menu-toggle-button {
+  padding: 0.5rem 0.95rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: rgba(18, 54, 70, 0.65);
+  color: #f8f4eb;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.menu-toggle-button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 222, 178, 0.55);
+}
+
+.menu-toggle-button.is-active {
+  background: linear-gradient(135deg, rgba(255, 210, 148, 0.78), rgba(255, 178, 107, 0.78));
+  color: #1f2e36;
+  border-color: rgba(255, 234, 205, 0.75);
+}
+
+.top-menu-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
 .menu-instructions {
   font-size: 0.9rem;
-  line-height: 1.3;
+  line-height: 1.35;
   color: rgba(240, 245, 248, 0.92);
-  max-width: 320px;
+  max-width: 540px;
 }
 
 .menu-instructions strong {
@@ -145,12 +195,12 @@
 
 .bottom-menu {
   align-self: center;
-  width: min(100%, 520px);
+  width: min(100%, 1100px);
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
-  padding: 0.85rem 1.6rem;
+  padding: 0.85rem 1.75rem;
 }
 
 .ship-title {
@@ -163,6 +213,8 @@
 .ship-stats {
   display: flex;
   gap: 1.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .ship-stat {
@@ -191,8 +243,15 @@
   }
 
   .top-menu {
-    gap: 1rem;
     padding: 0.75rem 1.25rem;
+  }
+
+  .top-menu--expanded {
+    padding-bottom: 1.15rem;
+  }
+
+  .menu-actions {
+    justify-content: flex-start;
   }
 
   .menu-instructions {
@@ -208,8 +267,7 @@
   }
 
   .bottom-menu {
-    width: min(100%, 420px);
-    padding: 0.75rem 1.2rem;
+    padding: 0.75rem 1.25rem;
   }
 }
 
@@ -220,6 +278,11 @@
 
   .menu-instructions {
     font-size: 0.85rem;
+  }
+
+  .menu-actions {
+    width: 100%;
+    justify-content: flex-start;
   }
 
   .seed-buttons {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -206,6 +206,7 @@ function App() {
   const [seed, setSeed] = useState(() => generateRandomSeed())
   const [seedInput, setSeedInput] = useState(seed)
   const [copyStatus, setCopyStatus] = useState('')
+  const [activeMenu, setActiveMenu] = useState(null)
   const copyTimeoutRef = useRef(null)
 
   const seedData = useMemo(() => {
@@ -456,56 +457,115 @@ function App() {
     }, 2000)
   }
 
+  const handleMenuToggle = (menuKey) => {
+    setActiveMenu((current) => (current === menuKey ? null : menuKey))
+  }
+
+  const shipStatus = useMemo(() => {
+    if (boatState.anchorState === 'dropping') {
+      return 'Dropping anchor'
+    }
+
+    if (boatState.anchorState === 'anchored') {
+      return 'At anchor'
+    }
+
+    if (boatState.anchorState === 'weighing') {
+      return 'Weighing anchor'
+    }
+
+    if (boatState.speed > 10) {
+      return 'Under way'
+    }
+
+    return 'Idle'
+  }, [boatState.anchorState, boatState.speed])
+
+  const speedKnots = Math.round(boatState.speed)
+  const headingDegrees = Math.round(
+    (((boatState.heading % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2)) * (180 / Math.PI),
+  )
+
   return (
     <div className="app">
       <canvas ref={canvasRef} className="world-canvas" />
       <div className="ui-layer">
-        <div className="top-menu glass-panel">
-          <div className="menu-brand">SailTrade</div>
-          <div className="menu-instructions">
-            Catch the wind with <strong>↑</strong>/<strong>W</strong>, ease the sails with <strong>↓</strong>/<strong>S</strong>, and steer using <strong>←</strong>/<strong>→</strong> or <strong>A</strong>/<strong>D</strong>.
-          </div>
-          <form className="seed-form" onSubmit={handleSeedSubmit}>
-            <label htmlFor="seed-input" className="seed-label">
-              World Seed
-            </label>
-            <input
-              id="seed-input"
-              className="seed-input"
-              value={seedInput}
-              onChange={(event) => setSeedInput(event.target.value)}
-              placeholder="Enter or paste a seed"
-              spellCheck="false"
-            />
-            <div className="seed-buttons">
-              <button type="submit" className="seed-button">
-                Load
+        <div className={`top-menu glass-panel ${activeMenu ? 'top-menu--expanded' : ''}`}>
+          <div className="top-menu-header">
+            <div className="menu-brand">SailTrade</div>
+            <div className="menu-actions">
+              <button
+                type="button"
+                className={`menu-toggle-button ${activeMenu === 'seed' ? 'is-active' : ''}`}
+                onClick={() => handleMenuToggle('seed')}
+              >
+                World Seed
               </button>
-              <button type="button" className="seed-button" onClick={handleRandomSeed}>
-                Random
-              </button>
-              <button type="button" className="seed-button" onClick={handleCopySeed}>
-                Copy
+              <button
+                type="button"
+                className={`menu-toggle-button ${activeMenu === 'instructions' ? 'is-active' : ''}`}
+                onClick={() => handleMenuToggle('instructions')}
+              >
+                Instructions
               </button>
             </div>
-          </form>
-          <div className="seed-hint">
-            <span>Share this seed to sail the same waters.</span>
-            {copyStatus && <span className="seed-status">{copyStatus}</span>}
           </div>
+          {activeMenu === 'seed' && (
+            <div className="top-menu-content">
+              <form className="seed-form" onSubmit={handleSeedSubmit}>
+                <label htmlFor="seed-input" className="seed-label">
+                  World Seed
+                </label>
+                <input
+                  id="seed-input"
+                  className="seed-input"
+                  value={seedInput}
+                  onChange={(event) => setSeedInput(event.target.value)}
+                  placeholder="Enter or paste a seed"
+                  spellCheck="false"
+                />
+                <div className="seed-buttons">
+                  <button type="submit" className="seed-button">
+                    Load
+                  </button>
+                  <button type="button" className="seed-button" onClick={handleRandomSeed}>
+                    Random
+                  </button>
+                  <button type="button" className="seed-button" onClick={handleCopySeed}>
+                    Copy
+                  </button>
+                </div>
+              </form>
+              <div className="seed-hint">
+                <span>Share this seed to sail the same waters.</span>
+                {copyStatus && <span className="seed-status">{copyStatus}</span>}
+              </div>
+            </div>
+          )}
+          {activeMenu === 'instructions' && (
+            <div className="top-menu-content">
+              <div className="menu-instructions">
+                Catch the wind with <strong>↑</strong>/<strong>W</strong>, ease the sails with <strong>↓</strong>/<strong>S</strong>, and steer using
+                {' '}
+                <strong>←</strong>/<strong>→</strong> or <strong>A</strong>/<strong>D</strong>.
+              </div>
+            </div>
+          )}
         </div>
         <div className="bottom-menu glass-panel">
           <div className="ship-title">Ship</div>
           <div className="ship-stats">
             <div className="ship-stat">
               <span className="ship-stat-label">Speed</span>
-              <span className="ship-stat-value">{Math.round(boatState.speed)} kn</span>
+              <span className="ship-stat-value">{speedKnots} kn</span>
             </div>
             <div className="ship-stat">
               <span className="ship-stat-label">Heading</span>
-              <span className="ship-stat-value">
-                {Math.round((((boatState.heading % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2)) * (180 / Math.PI))}°
-              </span>
+              <span className="ship-stat-value">{headingDegrees}°</span>
+            </div>
+            <div className="ship-stat">
+              <span className="ship-stat-label">Status</span>
+              <span className="ship-stat-value">{shipStatus}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- rework the top HUD into a collapsible menu bar with toggles for instructions and world seed controls
- align the bottom HUD width with the header and add a live ship activity status readout
- update styles for the revised layouts and interactive header buttons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e051cbe704832483c86a1071056e95