### PR TITLE
Improve island visuals, collisions, and add mini-map

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -193,6 +193,30 @@
   font-weight: 600;
 }
 
+.mini-map-wrapper {
+  position: absolute;
+  right: 2.5rem;
+  bottom: 2.5rem;
+  opacity: 0;
+  transform: scale(0.95);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  pointer-events: none;
+}
+
+.mini-map-wrapper.is-visible {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.mini-map-canvas {
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  border: 1px solid rgba(224, 244, 255, 0.35);
+  box-shadow: 0 20px 55px rgba(5, 18, 27, 0.45);
+  background: rgba(6, 40, 58, 0.8);
+}
+
 .bottom-menu {
   align-self: center;
   width: min(100%, 1100px);


### PR DESCRIPTION
## Summary
- reduce beach coverage, adjust canopy layers, and regenerate tree clusters with richer broadleaf/conifer artwork
- upgrade collision detection to sample the boat hull against the coastline polygon so the hull stops at the visible shore
- add a toggleable circular mini map with UI wiring and styling to visualize nearby islands

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e05a4df6d483248c5b366cf3147c0f