### PR TITLE
Refine island presentation and HUD spacing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -196,7 +196,7 @@
 .mini-map-wrapper {
   position: absolute;
   right: 2.5rem;
-  bottom: 2.5rem;
+  bottom: calc(2.5rem + clamp(5rem, 16vh, 7.5rem));
   opacity: 0;
   transform: scale(0.95);
   transition: opacity 0.25s ease, transform 0.25s ease;
@@ -293,6 +293,11 @@
   .bottom-menu {
     padding: 0.75rem 1.25rem;
   }
+
+  .mini-map-wrapper {
+    right: 1.9rem;
+    bottom: calc(1.9rem + clamp(4.5rem, 18vh, 6.5rem));
+  }
 }
 
 @media (max-width: 600px) {
@@ -331,5 +336,10 @@
 
   .ship-stat-value {
     font-size: 1rem;
+  }
+
+  .mini-map-wrapper {
+    right: 1.4rem;
+    bottom: calc(1.4rem + clamp(4rem, 22vh, 5.5rem));
   }
 }


### PR DESCRIPTION
## Summary
- shrink beaches and remove striping while layering procedural textures across shore, sand, grass, and canopy
- add per-island shoreline wave animation with cached patterns for richer islands and halve the anchor chain length
- reposition the minimap above the lower HUD to keep it clear of other UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e060f2489083249019b62c6bfb3d2c