### PR TITLE
Add ship damage model and HUD indicators

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -261,6 +261,15 @@
   text-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
 }
 
+.ship-stat-sub {
+  display: inline-block;
+  margin-left: 0.35rem;
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(240, 245, 248, 0.7);
+}
+
 @media (max-width: 900px) {
   .ui-layer {
     padding: 1.2rem 1.2rem 1.6rem;


### PR DESCRIPTION
## Summary
- add hull health tracking with collision damage thresholds and speed penalties
- update ship control logic to clamp speed based on damage and drop sails on impact
- surface hull condition and effective top speed in the HUD

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e072574cfc8324900d40e57fb12b89