### PR TITLE
Add weather toggle options and align wind streak direction

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -102,6 +102,43 @@
   gap: 0.75rem;
 }
 
+.options-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  color: rgba(240, 245, 248, 0.92);
+}
+
+.options-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #ffe7bd;
+}
+
+.options-toggle input[type='checkbox'] {
+  width: 1.15rem;
+  height: 1.15rem;
+  accent-color: #ffb56b;
+  cursor: pointer;
+}
+
+.options-toggle-label {
+  cursor: pointer;
+}
+
+.options-description {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: rgba(240, 245, 248, 0.7);
+  max-width: 420px;
+}
+
 .menu-instructions {
   font-size: 0.9rem;
   line-height: 1.35;


### PR DESCRIPTION
## Summary
- add an options menu to the HUD with a weather toggle that disables wind mechanics and related UI when turned off
- hide weather controls and panels when weather is disabled while keeping mini map spacing consistent
- adjust wind streak animation travel so streaks move with the wind direction

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0816bdc04832482971ef342b60cdb