### PR TITLE
Add named islands and interactive world map overlay

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -256,6 +256,100 @@
   background: rgba(6, 40, 58, 0.8);
 }
 
+.world-map-wrapper {
+  flex: 1;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 1.25rem 0 1.5rem;
+  pointer-events: none;
+}
+
+.world-map-panel.hud-panel {
+  flex: 1;
+  width: min(100%, 1100px);
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: 1.1rem;
+  padding: 1.1rem 1.5rem 1.4rem;
+  pointer-events: auto;
+  min-height: 0;
+}
+
+.world-map-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.world-map-title {
+  font-size: 0.78rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(255, 231, 189, 0.95);
+}
+
+.world-map-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.world-map-hint {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(240, 245, 248, 0.72);
+}
+
+.world-map-close {
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.26);
+  background: rgba(18, 54, 70, 0.62);
+  color: #f8f4eb;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.world-map-close:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 222, 178, 0.55);
+  background: linear-gradient(135deg, rgba(255, 210, 148, 0.4), rgba(255, 178, 107, 0.32));
+  color: #1f2e36;
+}
+
+.world-map-canvas-container {
+  flex: 1;
+  min-height: 0;
+  border-radius: 18px;
+  border: 1px solid rgba(224, 244, 255, 0.22);
+  background: radial-gradient(circle at 30% 20%, rgba(40, 110, 142, 0.32), rgba(4, 28, 40, 0.78));
+  overflow: hidden;
+  box-shadow: inset 0 18px 40px rgba(3, 16, 26, 0.45);
+  pointer-events: auto;
+}
+
+.world-map-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  cursor: grab;
+}
+
+.world-map-canvas.is-panning {
+  cursor: grabbing;
+}
+
 .bottom-panels {
   align-self: center;
   width: min(100%, 1100px);


### PR DESCRIPTION
## Summary
- generate English-inspired names for each generated island
- add a zoomable, pannable sea chart that lists island names and the player ship
- wire the new map overlay to the top menu button and M key while auto-hiding the mini map

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0851ce01c8324aac1959cc7fef2de